### PR TITLE
implement new kafka key and protobuf serializer

### DIFF
--- a/exporter/src/main/java/io/zeebe/exporters/kafka/KafkaExporter.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/KafkaExporter.java
@@ -27,7 +27,6 @@ import io.zeebe.exporters.kafka.producer.DefaultKafkaProducerFactory;
 import io.zeebe.exporters.kafka.producer.KafkaProducerFactory;
 import io.zeebe.exporters.kafka.record.KafkaRecordFilter;
 import io.zeebe.exporters.kafka.record.RecordHandler;
-import io.zeebe.exporters.kafka.serde.RecordId;
 import io.zeebe.exporters.kafka.util.Request;
 import io.zeebe.exporters.kafka.util.RequestQueue;
 import io.zeebe.protocol.record.Record;
@@ -55,7 +54,7 @@ public class KafkaExporter implements Exporter {
   private Logger logger;
 
   @SuppressWarnings("rawtypes")
-  private Producer<RecordId, Record> producer;
+  private Producer<Long, Record> producer;
 
   private Config config;
   private RecordHandler recordHandler;
@@ -120,7 +119,7 @@ public class KafkaExporter implements Exporter {
     }
 
     if (recordHandler.test(record)) {
-      final ProducerRecord<RecordId, Record> kafkaRecord = recordHandler.transform(record);
+      final ProducerRecord<Long, Record> kafkaRecord = recordHandler.transform(record);
       final Future<RecordMetadata> future = producer.send(kafkaRecord);
       final Request request = new Request(record.getPosition(), future);
 

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/config/ProducerConfig.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/config/ProducerConfig.java
@@ -38,18 +38,21 @@ public final class ProducerConfig {
   private final Map<String, Object> config;
   private final Duration requestTimeout;
   private final List<String> servers;
+  private final String format;
 
   public ProducerConfig(
       final String clientId,
       final Duration closeTimeout,
       final Map<String, Object> config,
       final Duration requestTimeout,
-      final List<String> servers) {
+      final List<String> servers,
+      final String format) {
     this.clientId = Objects.requireNonNull(clientId);
     this.closeTimeout = Objects.requireNonNull(closeTimeout);
     this.config = Objects.requireNonNull(config);
     this.requestTimeout = Objects.requireNonNull(requestTimeout);
     this.servers = Objects.requireNonNull(servers);
+    this.format = Objects.requireNonNull(format);
   }
 
   public @NonNull String getClientId() {
@@ -72,9 +75,13 @@ public final class ProducerConfig {
     return servers;
   }
 
+  public @NonNull String getFormat() {
+    return format;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(clientId, closeTimeout, config, requestTimeout, servers);
+    return Objects.hash(clientId, closeTimeout, config, requestTimeout, servers, format);
   }
 
   @Override
@@ -90,6 +97,7 @@ public final class ProducerConfig {
         && Objects.equals(getCloseTimeout(), that.getCloseTimeout())
         && Objects.equals(getConfig(), that.getConfig())
         && Objects.equals(getRequestTimeout(), that.getRequestTimeout())
-        && Objects.equals(getServers(), that.getServers());
+        && Objects.equals(getServers(), that.getServers())
+        && Objects.equals(getFormat(), that.getFormat());
   }
 }

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/config/parser/RawProducerConfigParser.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/config/parser/RawProducerConfigParser.java
@@ -45,6 +45,7 @@ public class RawProducerConfigParser implements ConfigParser<RawProducerConfig, 
   static final String DEFAULT_CLIENT_ID = "zeebe";
   static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(20);
   static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+  static final String DEFAULT_FORMAT = "json";
 
   @Override
   public @NonNull ProducerConfig parse(final @Nullable RawProducerConfig config) {
@@ -59,8 +60,9 @@ public class RawProducerConfigParser implements ConfigParser<RawProducerConfig, 
         get(config.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT, Duration::ofMillis);
     final Map<String, Object> producerConfig =
         get(config.config, new HashMap<>(), this::parseProperties);
+    final String format = get(config.format, DEFAULT_FORMAT);
 
-    return new ProducerConfig(clientId, closeTimeout, producerConfig, requestTimeout, servers);
+    return new ProducerConfig(clientId, closeTimeout, producerConfig, requestTimeout, servers, format);
   }
 
   private @NonNull Map<String, Object> parseProperties(final @NonNull String propertiesString) {

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/config/raw/RawProducerConfig.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/config/raw/RawProducerConfig.java
@@ -50,4 +50,11 @@ public class RawProducerConfig {
    * Maps to ProducerConfig.BOOTSTRAP_SERVERS_CONFIG
    */
   public String servers;
+
+  /**
+   * The serialisation format for the message value
+   *
+   * <p>default is "json" also supported is "protobuf"
+   */
+  public String format;
 }

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/producer/DefaultKafkaProducerFactory.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/producer/DefaultKafkaProducerFactory.java
@@ -17,8 +17,6 @@ package io.zeebe.exporters.kafka.producer;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.zeebe.exporters.kafka.config.Config;
-import io.zeebe.exporters.kafka.serde.RecordId;
-import io.zeebe.exporters.kafka.serde.RecordIdSerializer;
 import io.zeebe.exporters.kafka.serde.RecordSerializer;
 import io.zeebe.protocol.record.Record;
 import java.util.HashMap;
@@ -26,6 +24,7 @@ import java.util.Map;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.LongSerializer;
 
 /**
  * {@link DefaultKafkaProducerFactory} is the default implementation of {@link KafkaProducerFactory}
@@ -44,7 +43,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 public final class DefaultKafkaProducerFactory implements KafkaProducerFactory {
   @SuppressWarnings("rawtypes")
   @Override
-  public @NonNull Producer<RecordId, Record> newProducer(final @NonNull Config config) {
+  public @NonNull Producer<Long, Record> newProducer(final @NonNull Config config) {
     final Map<String, Object> options = new HashMap<>();
 
     options.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
@@ -72,7 +71,7 @@ public final class DefaultKafkaProducerFactory implements KafkaProducerFactory {
     // allow user configuration to override producer options
     options.putAll(config.getProducer().getConfig());
 
-    options.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, RecordIdSerializer.class);
+    options.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
     options.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, RecordSerializer.class);
 
     return new KafkaProducer<>(options);

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/producer/DefaultKafkaProducerFactory.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/producer/DefaultKafkaProducerFactory.java
@@ -17,6 +17,7 @@ package io.zeebe.exporters.kafka.producer;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.zeebe.exporters.kafka.config.Config;
+import io.zeebe.exporters.kafka.serde.ProtobufRecordSerializer;
 import io.zeebe.exporters.kafka.serde.RecordSerializer;
 import io.zeebe.protocol.record.Record;
 import java.util.HashMap;
@@ -72,7 +73,11 @@ public final class DefaultKafkaProducerFactory implements KafkaProducerFactory {
     options.putAll(config.getProducer().getConfig());
 
     options.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
-    options.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, RecordSerializer.class);
+    if ("protobuf".equals(config.getProducer().getFormat())) {
+      options.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ProtobufRecordSerializer.class);
+    } else {
+      options.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, RecordSerializer.class);
+    }
 
     return new KafkaProducer<>(options);
   }

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/producer/KafkaProducerFactory.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/producer/KafkaProducerFactory.java
@@ -17,7 +17,6 @@ package io.zeebe.exporters.kafka.producer;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.zeebe.exporters.kafka.config.Config;
-import io.zeebe.exporters.kafka.serde.RecordId;
 import io.zeebe.protocol.record.Record;
 import org.apache.kafka.clients.producer.Producer;
 
@@ -29,5 +28,5 @@ import org.apache.kafka.clients.producer.Producer;
 @FunctionalInterface
 public interface KafkaProducerFactory {
   @NonNull
-  Producer<RecordId, Record> newProducer(@NonNull Config config);
+  Producer<Long, Record> newProducer(@NonNull Config config);
 }

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/record/RecordHandler.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/record/RecordHandler.java
@@ -18,8 +18,8 @@ package io.zeebe.exporters.kafka.record;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.zeebe.exporters.kafka.config.RecordConfig;
 import io.zeebe.exporters.kafka.config.RecordsConfig;
-import io.zeebe.exporters.kafka.serde.RecordId;
 import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.value.WorkflowInstanceRelated;
 import java.util.Objects;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
@@ -43,10 +43,13 @@ public final class RecordHandler {
    * @param record the record to transform
    * @return the transformed record
    */
-  public @NonNull ProducerRecord<RecordId, Record> transform(final @NonNull Record record) {
+  public @NonNull ProducerRecord<Long, Record> transform(final @NonNull Record record) {
     final RecordConfig config = getRecordConfig(record);
-    return new ProducerRecord<>(
-        config.getTopic(), new RecordId(record.getPartitionId(), record.getPosition()), record);
+    long key = record.getPartitionId();
+    if (record instanceof WorkflowInstanceRelated) {
+      key = ((WorkflowInstanceRelated) record).getWorkflowInstanceKey();
+    }
+    return new ProducerRecord<>(config.getTopic(), key, record);
   }
 
   /**

--- a/exporter/src/test/java/io/zeebe/exporters/kafka/KafkaExporterTest.java
+++ b/exporter/src/test/java/io/zeebe/exporters/kafka/KafkaExporterTest.java
@@ -17,14 +17,13 @@ package io.zeebe.exporters.kafka;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.Assert.assertThat;
 
 import io.zeebe.exporters.kafka.config.Config;
 import io.zeebe.exporters.kafka.config.parser.MockConfigParser;
 import io.zeebe.exporters.kafka.config.parser.RawConfigParser;
 import io.zeebe.exporters.kafka.config.raw.RawConfig;
 import io.zeebe.exporters.kafka.producer.MockKafkaProducerFactory;
-import io.zeebe.exporters.kafka.serde.RecordId;
-import io.zeebe.exporters.kafka.serde.RecordIdSerializer;
 import io.zeebe.exporters.kafka.serde.RecordSerializer;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.test.exporter.ExporterTestHarness;
@@ -32,6 +31,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.LongSerializer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class KafkaExporterTest {
   @Before
   public void setup() {
     mockProducerFactory.mockProducer =
-        new MockProducer<>(true, new RecordIdSerializer(), new RecordSerializer());
+        new MockProducer<>(true, new LongSerializer(), new RecordSerializer());
     mockConfigParser.config = mockConfigParser.parse(rawConfig);
   }
 
@@ -69,10 +69,10 @@ public class KafkaExporterTest {
             });
 
     // then
-    final ProducerRecord<RecordId, Record> expected =
+    final ProducerRecord<Long, Record> expected =
         new ProducerRecord<>(
             mockConfigParser.config.getRecords().getDefaults().getTopic(),
-            new RecordId(record.getPartitionId(), record.getPosition()),
+            (long) record.getPartitionId(),
             record);
     assertThat(mockProducerFactory.mockProducer.history()).hasSize(1).containsExactly(expected);
   }

--- a/exporter/src/test/java/io/zeebe/exporters/kafka/producer/MockKafkaProducerFactory.java
+++ b/exporter/src/test/java/io/zeebe/exporters/kafka/producer/MockKafkaProducerFactory.java
@@ -17,7 +17,6 @@ package io.zeebe.exporters.kafka.producer;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.zeebe.exporters.kafka.config.Config;
-import io.zeebe.exporters.kafka.serde.RecordId;
 import io.zeebe.protocol.record.Record;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -30,10 +29,10 @@ import org.apache.kafka.clients.producer.Producer;
  */
 @SuppressWarnings("rawtypes")
 public class MockKafkaProducerFactory implements KafkaProducerFactory {
-  public MockProducer<RecordId, Record> mockProducer;
+  public MockProducer<Long, Record> mockProducer;
 
   @Override
-  public @NonNull Producer<RecordId, Record> newProducer(final @NonNull Config config) {
+  public @NonNull Producer<Long, Record> newProducer(final @NonNull Config config) {
     if (mockProducer == null) {
       mockProducer = new MockProducer<>();
     }

--- a/exporter/src/test/java/io/zeebe/exporters/kafka/record/RecordHandlerTest.java
+++ b/exporter/src/test/java/io/zeebe/exporters/kafka/record/RecordHandlerTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.exporters.kafka.config.RecordConfig;
 import io.zeebe.exporters.kafka.config.RecordsConfig;
-import io.zeebe.exporters.kafka.serde.RecordId;
 import io.zeebe.protocol.immutables.record.ImmutableDeploymentRecordValue;
 import io.zeebe.protocol.immutables.record.ImmutableRecord;
 import io.zeebe.protocol.record.Record;
@@ -47,12 +46,11 @@ public class RecordHandlerTest {
     final RecordHandler recordHandler = new RecordHandler(newRecordsConfig(RecordType.COMMAND));
 
     // when
-    final ProducerRecord<RecordId, Record> transformed = recordHandler.transform(record);
+    final ProducerRecord<Long, Record> transformed = recordHandler.transform(record);
 
     // then
     assertThat(transformed.topic()).isEqualTo(deploymentRecordConfig.getTopic());
-    assertThat(transformed.key())
-        .isEqualTo(new RecordId(record.getPartitionId(), record.getPosition()));
+    assertThat(transformed.key()).isEqualTo(record.getPartitionId());
     assertThat(transformed.value()).isEqualTo(record);
   }
 

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -17,6 +17,7 @@
 
   <properties>
     <version.java>8</version.java>
+    <version.exporter.protobuf>0.11.0</version.exporter.protobuf>
   </properties>
 
   <dependencies>
@@ -55,5 +56,18 @@
       <artifactId>spotbugs-annotations</artifactId>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-exporter-protobuf</artifactId>
+      <version>${version.exporter.protobuf}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.daniel-shuy</groupId>
+      <artifactId>kafka-protobuf-serde</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/serde/src/main/java/io/zeebe/exporters/kafka/serde/ProtobufRecordDeserializer.java
+++ b/serde/src/main/java/io/zeebe/exporters/kafka/serde/ProtobufRecordDeserializer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporters.kafka.serde;
+
+import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.zeebe.exporter.proto.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+
+/**
+ * A {@link Deserializer} implementations for {@link com.google.protobuf.Message} objects. It
+ * expects the records to be encoded in protobuf format as per ProtobufRecordSerializer
+ *
+ * <p>The records are dezerialised and the unpacked into type specific proto buf records e.g.
+ * Schema.DeploymentRecord
+ */
+public final class ProtobufRecordDeserializer implements Deserializer<com.google.protobuf.Message> {
+
+  private static final List<Class<? extends com.google.protobuf.Message>> RECORD_MESSAGE_TYPES;
+
+  static {
+    RECORD_MESSAGE_TYPES = new ArrayList<>();
+    RECORD_MESSAGE_TYPES.add(Schema.DeploymentRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.JobRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.JobBatchRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.ErrorRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.VariableRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.VariableDocumentRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.MessageStartEventSubscriptionRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.MessageSubscriptionRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.MessageRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.WorkflowInstanceRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.WorkflowInstanceCreationRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.WorkflowInstanceResultRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.WorkflowInstanceSubscriptionRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.TimerRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.IncidentRecord.class);
+  }
+
+  private static final KafkaProtobufDeserializer<Schema.Record> PROTOBUF_DESERIALIZER =
+      new KafkaProtobufDeserializer<>(Schema.Record.parser());
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {}
+
+  @Override
+  public com.google.protobuf.Message deserialize(final String topic, final byte[] data) {
+    final Schema.Record record = PROTOBUF_DESERIALIZER.deserialize(topic, data);
+    return unpackRecord(record);
+  }
+
+  private com.google.protobuf.Message unpackRecord(Schema.Record record) {
+    for (Class<? extends com.google.protobuf.Message> type : RECORD_MESSAGE_TYPES) {
+      if (record.getRecord().is(type)) {
+        try {
+          return record.getRecord().unpack(type);
+        } catch (InvalidProtocolBufferException e) {
+          throw new SerializationException(e);
+        }
+      }
+    }
+    throw new SerializationException("Unrecognised record type");
+  }
+
+  @Override
+  public void close() {}
+}

--- a/serde/src/main/java/io/zeebe/exporters/kafka/serde/ProtobufRecordSerializer.java
+++ b/serde/src/main/java/io/zeebe/exporters/kafka/serde/ProtobufRecordSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporters.kafka.serde;
+
+import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.zeebe.exporter.proto.RecordTransformer;
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.protocol.record.Record;
+import java.util.Map;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * A {@link Serializer} implementations for {@link Record} objects which uses
+ * KafkaProtobufSerializer to serialise Schema.Record instances to kafak
+ */
+@SuppressWarnings("rawtypes")
+public final class ProtobufRecordSerializer implements Serializer<Record> {
+  private final KafkaProtobufSerializer<Schema.Record> delegate;
+
+  public ProtobufRecordSerializer() {
+    this(new KafkaProtobufSerializer<Schema.Record>());
+  }
+
+  public ProtobufRecordSerializer(final @NonNull KafkaProtobufSerializer<Schema.Record> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    delegate.configure(configs, isKey);
+  }
+
+  @Override
+  public byte[] serialize(final String topic, final Record data) {
+    return delegate.serialize(topic, RecordTransformer.toGenericRecord(data));
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+}


### PR DESCRIPTION
This implements two changes

1) https://github.com/zeebe-io/zeebe-kafka-exporter/issues/31
 change to using Long kafka keys to ensure that the order of consuming messages is consistent. 

a) if the Record is WorkflowInstanceRelated the workflowInstanceKey is used as the message key
b) otherwise the zeebe partition id is used as the message key

This is a breaking change, however using RecordID as keys leads to out of order consuming of records so may be considered broken.

2) Adding support for serializing (and deserializing) using protobuf.

Introduces new producer config field ```format``` with default ```json``` and supporting ```protobuf``` to enable using ProtobufRecordSerializer.  Then consumers can use ProtobufRecordDeserializer to consume record type specific instances


A prime motivator to create this is to be able to implement kafka-importers in ```zeeqs``` and ```zeebe-simple-monitor``` (https://github.com/zeebe-io/zeebe-simple-monitor/pull/183) as well as providing a durable pipeline for exporters 