### PR TITLE
implement protobuf serde

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 target/
 *.iml
 *.jar
+.settings
+.classpath
+.project
+.factorypath
+.vscode

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/config/ProducerConfig.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/config/ProducerConfig.java
@@ -17,9 +17,11 @@ package io.zeebe.exporters.kafka.config;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * {@link ProducerConfig} is used by instances of {@link
@@ -38,18 +40,21 @@ public final class ProducerConfig {
   private final Map<String, Object> config;
   private final Duration requestTimeout;
   private final List<String> servers;
+  private final Format format;
 
   public ProducerConfig(
       final String clientId,
       final Duration closeTimeout,
       final Map<String, Object> config,
       final Duration requestTimeout,
-      final List<String> servers) {
+      final List<String> servers,
+      final Format format) {
     this.clientId = Objects.requireNonNull(clientId);
     this.closeTimeout = Objects.requireNonNull(closeTimeout);
     this.config = Objects.requireNonNull(config);
     this.requestTimeout = Objects.requireNonNull(requestTimeout);
     this.servers = Objects.requireNonNull(servers);
+    this.format = Objects.requireNonNull(format);
   }
 
   public @NonNull String getClientId() {
@@ -72,9 +77,13 @@ public final class ProducerConfig {
     return servers;
   }
 
+  public @NonNull Format getFormat() {
+    return format;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(clientId, closeTimeout, config, requestTimeout, servers);
+    return Objects.hash(clientId, closeTimeout, config, requestTimeout, servers, format);
   }
 
   @Override
@@ -90,6 +99,38 @@ public final class ProducerConfig {
         && Objects.equals(getCloseTimeout(), that.getCloseTimeout())
         && Objects.equals(getConfig(), that.getConfig())
         && Objects.equals(getRequestTimeout(), that.getRequestTimeout())
-        && Objects.equals(getServers(), that.getServers());
+        && Objects.equals(getServers(), that.getServers())
+        && Objects.equals(getFormat(), that.getFormat());
+  }
+
+  public enum Format {
+    JSON("json"),
+    PROTOBUF("protobuf");
+
+    private final String formatName;
+
+    Format(final String formatName) {
+      this.formatName = formatName;
+    }
+
+    public String getFormatName() {
+      return formatName;
+    }
+
+    public static Format forName(final String name) {
+      if (JSON.formatName.equals(name)) {
+        return JSON;
+      } else if (PROTOBUF.formatName.equals(name)) {
+        return PROTOBUF;
+      } else {
+        throw new IllegalArgumentException(
+            String.format(
+                "Unknown format name: %s, valid values are %s",
+                name,
+                Arrays.stream(Format.values())
+                    .map(Format::getFormatName)
+                    .collect(Collectors.joining(", "))));
+      }
+    }
   }
 }

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/config/parser/RawProducerConfigParser.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/config/parser/RawProducerConfigParser.java
@@ -20,6 +20,7 @@ import static io.zeebe.exporters.kafka.config.parser.ConfigParserUtil.get;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.zeebe.exporters.kafka.config.ProducerConfig;
+import io.zeebe.exporters.kafka.config.ProducerConfig.Format;
 import io.zeebe.exporters.kafka.config.raw.RawProducerConfig;
 import java.io.IOException;
 import java.io.Reader;
@@ -45,6 +46,7 @@ public class RawProducerConfigParser implements ConfigParser<RawProducerConfig, 
   static final String DEFAULT_CLIENT_ID = "zeebe";
   static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(20);
   static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+  static final String DEFAULT_FORMAT = Format.JSON.getFormatName();
 
   @Override
   public @NonNull ProducerConfig parse(final @Nullable RawProducerConfig config) {
@@ -59,8 +61,10 @@ public class RawProducerConfigParser implements ConfigParser<RawProducerConfig, 
         get(config.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT, Duration::ofMillis);
     final Map<String, Object> producerConfig =
         get(config.config, new HashMap<>(), this::parseProperties);
+    final Format format = Format.forName(get(config.format, DEFAULT_FORMAT));
 
-    return new ProducerConfig(clientId, closeTimeout, producerConfig, requestTimeout, servers);
+    return new ProducerConfig(
+        clientId, closeTimeout, producerConfig, requestTimeout, servers, format);
   }
 
   private @NonNull Map<String, Object> parseProperties(final @NonNull String propertiesString) {

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/config/raw/RawProducerConfig.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/config/raw/RawProducerConfig.java
@@ -50,4 +50,12 @@ public class RawProducerConfig {
    * Maps to ProducerConfig.BOOTSTRAP_SERVERS_CONFIG
    */
   public String servers;
+
+  /**
+   * The serialisation format for the message value
+   *
+   * <p>default is "json" also supported is "protobuf", @see {@link
+   * io.zeebe.exporters.kafka.config.ProducerConfig.Format}
+   */
+  public String format;
 }

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/producer/DefaultKafkaProducerFactory.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/producer/DefaultKafkaProducerFactory.java
@@ -17,6 +17,7 @@ package io.zeebe.exporters.kafka.producer;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.zeebe.exporters.kafka.config.Config;
+import io.zeebe.exporters.kafka.serde.ProtobufRecordSerializer;
 import io.zeebe.exporters.kafka.serde.RecordId;
 import io.zeebe.exporters.kafka.serde.RecordIdSerializer;
 import io.zeebe.exporters.kafka.serde.RecordSerializer;
@@ -73,7 +74,18 @@ public final class DefaultKafkaProducerFactory implements KafkaProducerFactory {
     options.putAll(config.getProducer().getConfig());
 
     options.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, RecordIdSerializer.class);
-    options.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, RecordSerializer.class);
+    switch (config.getProducer().getFormat()) {
+      case JSON:
+        {
+          options.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, RecordSerializer.class);
+          break;
+        }
+      case PROTOBUF:
+        {
+          options.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ProtobufRecordSerializer.class);
+          break;
+        }
+    }
 
     return new KafkaProducer<>(options);
   }

--- a/exporter/src/test/java/io/zeebe/exporters/kafka/config/parser/RawProducerConfigParserTest.java
+++ b/exporter/src/test/java/io/zeebe/exporters/kafka/config/parser/RawProducerConfigParserTest.java
@@ -18,6 +18,7 @@ package io.zeebe.exporters.kafka.config.parser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.exporters.kafka.config.ProducerConfig;
+import io.zeebe.exporters.kafka.config.ProducerConfig.Format;
 import io.zeebe.exporters.kafka.config.raw.RawProducerConfig;
 import java.time.Duration;
 import java.util.Collections;
@@ -38,18 +39,14 @@ public class RawProducerConfigParserTest {
 
     // then
     assertThat(parsed)
-        .extracting(
-            "servers",
-            "clientId",
-            "closeTimeout",
-            "requestTimeout",
-            "config")
+        .extracting("servers", "clientId", "closeTimeout", "requestTimeout", "config", "format")
         .containsExactly(
             RawProducerConfigParser.DEFAULT_SERVERS,
             RawProducerConfigParser.DEFAULT_CLIENT_ID,
             RawProducerConfigParser.DEFAULT_CLOSE_TIMEOUT,
             RawProducerConfigParser.DEFAULT_REQUEST_TIMEOUT,
-            new HashMap<>());
+            new HashMap<>(),
+            Format.JSON);
   }
 
   @Test
@@ -61,23 +58,20 @@ public class RawProducerConfigParserTest {
     config.closeTimeoutMs = 3000L;
     config.requestTimeoutMs = 3000L;
     config.config = "linger.ms=5\nmax.buffer.count=2";
+    config.format = "protobuf";
 
     // when
     final ProducerConfig parsed = parser.parse(config);
 
     // then
     assertThat(parsed)
-        .extracting(
-            "servers",
-            "clientId",
-            "closeTimeout",
-            "requestTimeout",
-            "config")
+        .extracting("servers", "clientId", "closeTimeout", "requestTimeout", "config", "format")
         .containsExactly(
             Collections.singletonList("localhost:3000"),
             "client",
             Duration.ofSeconds(3),
             Duration.ofSeconds(3),
-            Map.of("linger.ms", "5", "max.buffer.count", "2"));
+            Map.of("linger.ms", "5", "max.buffer.count", "2"),
+            Format.PROTOBUF);
   }
 }

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -17,6 +17,9 @@
 
   <properties>
     <version.java>8</version.java>
+    <version.exporter.protobuf>0.11.0</version.exporter.protobuf>
+    <version.junit>4.12</version.junit>
+    <version.assertj>3.16.1</version.assertj>
   </properties>
 
   <dependencies>
@@ -48,6 +51,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -55,5 +59,32 @@
       <artifactId>spotbugs-annotations</artifactId>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-exporter-protobuf</artifactId>
+      <version>${version.exporter.protobuf}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.daniel-shuy</groupId>
+      <artifactId>kafka-protobuf-serde</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${version.junit}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${version.assertj}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/serde/src/main/java/io/zeebe/exporters/kafka/serde/ProtobufRecordDeserializer.java
+++ b/serde/src/main/java/io/zeebe/exporters/kafka/serde/ProtobufRecordDeserializer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporters.kafka.serde;
+
+import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.zeebe.exporter.proto.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+
+/**
+ * A {@link Deserializer} implementations for {@link com.google.protobuf.Message} objects. It
+ * expects the records to be encoded in protobuf format as per ProtobufRecordSerializer
+ *
+ * <p>The records are dezerialised and the unpacked into type specific proto buf records e.g.
+ * Schema.DeploymentRecord
+ */
+public final class ProtobufRecordDeserializer implements Deserializer<com.google.protobuf.Message> {
+
+  private static final List<Class<? extends com.google.protobuf.Message>> RECORD_MESSAGE_TYPES;
+
+  static {
+    RECORD_MESSAGE_TYPES = new ArrayList<>();
+    RECORD_MESSAGE_TYPES.add(Schema.DeploymentRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.JobRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.JobBatchRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.ErrorRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.VariableRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.VariableDocumentRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.MessageStartEventSubscriptionRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.MessageSubscriptionRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.MessageRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.WorkflowInstanceRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.WorkflowInstanceCreationRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.WorkflowInstanceResultRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.WorkflowInstanceSubscriptionRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.TimerRecord.class);
+    RECORD_MESSAGE_TYPES.add(Schema.IncidentRecord.class);
+  }
+
+  private static final KafkaProtobufDeserializer<Schema.Record> PROTOBUF_DESERIALIZER =
+      new KafkaProtobufDeserializer<>(Schema.Record.parser());
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {}
+
+  @Override
+  public com.google.protobuf.Message deserialize(final String topic, final byte[] data) {
+    final Schema.Record record = PROTOBUF_DESERIALIZER.deserialize(topic, data);
+    return unpackRecord(record);
+  }
+
+  private com.google.protobuf.Message unpackRecord(Schema.Record record) {
+    for (Class<? extends com.google.protobuf.Message> type : RECORD_MESSAGE_TYPES) {
+      if (record.getRecord().is(type)) {
+        try {
+          return record.getRecord().unpack(type);
+        } catch (InvalidProtocolBufferException e) {
+          throw new SerializationException(e);
+        }
+      }
+    }
+    throw new SerializationException("Unrecognised record type");
+  }
+
+  @Override
+  public void close() {}
+}

--- a/serde/src/main/java/io/zeebe/exporters/kafka/serde/ProtobufRecordSerializer.java
+++ b/serde/src/main/java/io/zeebe/exporters/kafka/serde/ProtobufRecordSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporters.kafka.serde;
+
+import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.zeebe.exporter.proto.RecordTransformer;
+import io.zeebe.exporter.proto.Schema;
+import io.zeebe.protocol.record.Record;
+import java.util.Map;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * A {@link Serializer} implementations for {@link Record} objects which uses
+ * KafkaProtobufSerializer to serialise Schema.Record instances to kafak
+ */
+@SuppressWarnings("rawtypes")
+public final class ProtobufRecordSerializer implements Serializer<Record> {
+  private final KafkaProtobufSerializer<Schema.Record> delegate;
+
+  public ProtobufRecordSerializer() {
+    this(new KafkaProtobufSerializer<Schema.Record>());
+  }
+
+  public ProtobufRecordSerializer(final @NonNull KafkaProtobufSerializer<Schema.Record> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    delegate.configure(configs, isKey);
+  }
+
+  @Override
+  public byte[] serialize(final String topic, final Record data) {
+    return delegate.serialize(topic, RecordTransformer.toGenericRecord(data));
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+}

--- a/serde/src/test/java/io/zeebe/exporters/kafka/serde/JsonSerdeTest.java
+++ b/serde/src/test/java/io/zeebe/exporters/kafka/serde/JsonSerdeTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporters.kafka.serde;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.protocol.immutables.record.ImmutableDeploymentRecordValue;
+import io.zeebe.protocol.immutables.record.ImmutableRecord;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
+import io.zeebe.protocol.record.intent.Intent;
+import io.zeebe.protocol.record.value.DeploymentRecordValue;
+import java.util.Map;
+import org.junit.Test;
+
+public class JsonSerdeTest {
+
+  @Test
+  public void testJsonSerde() {
+
+    try (RecordSerializer serializer = new RecordSerializer()) {
+      serializer.configure(Map.of(), false);
+
+      try (RecordDeserializer deSerializer = new RecordDeserializer()) {
+        deSerializer.configure(Map.of(), false);
+
+        final byte[] data =
+            serializer.serialize(
+                "zeebe",
+                ImmutableRecord.builder()
+                    .timestamp(1)
+                    .key(1)
+                    .partitionId(1)
+                    .position(1)
+                    .intent(
+                        Intent.fromProtocolValue(
+                            ValueType.DEPLOYMENT, DeploymentIntent.CREATE.getIntent()))
+                    .valueType(ValueType.DEPLOYMENT)
+                    .recordType(RecordType.COMMAND)
+                    .value(ImmutableDeploymentRecordValue.builder().build())
+                    .build());
+
+        final Record<?> message = deSerializer.deserialize("zeebe", data);
+
+        // not testing the implementation of toJson/fromJson, just confirming that the
+        // RecordSerializer/RecordDeserializer do the right thing
+        assertThat(message.getValue()).isInstanceOf(DeploymentRecordValue.class);
+      }
+    }
+  }
+}

--- a/serde/src/test/java/io/zeebe/exporters/kafka/serde/ProtobufSerdeTest.java
+++ b/serde/src/test/java/io/zeebe/exporters/kafka/serde/ProtobufSerdeTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporters.kafka.serde;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.Message;
+import io.zeebe.exporter.proto.Schema.DeploymentRecord;
+import io.zeebe.protocol.immutables.record.ImmutableDeploymentRecordValue;
+import io.zeebe.protocol.immutables.record.ImmutableRecord;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
+import io.zeebe.protocol.record.intent.Intent;
+import java.util.Map;
+import org.junit.Test;
+
+public class ProtobufSerdeTest {
+
+  @Test
+  public void testProtobufSerde() {
+
+    try (ProtobufRecordSerializer serializer = new ProtobufRecordSerializer()) {
+      serializer.configure(Map.of(), false);
+
+      try (ProtobufRecordDeserializer deSerializer = new ProtobufRecordDeserializer()) {
+        deSerializer.configure(Map.of(), false);
+
+        final byte[] data =
+            serializer.serialize(
+                "zeebe",
+                ImmutableRecord.builder()
+                    .timestamp(1)
+                    .key(1)
+                    .partitionId(1)
+                    .position(1)
+                    .intent(
+                        Intent.fromProtocolValue(
+                            ValueType.DEPLOYMENT, DeploymentIntent.CREATE.getIntent()))
+                    .valueType(ValueType.DEPLOYMENT)
+                    .recordType(RecordType.COMMAND)
+                    .value(ImmutableDeploymentRecordValue.builder().build())
+                    .build());
+
+        final Message message = deSerializer.deserialize("zeebe", data);
+
+        // not testing the implementation of RecordTransformer, but just confirming that the
+        // Serializer/Deserialize perform the correct steps
+        assertThat(message).isInstanceOf(DeploymentRecord.class);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding support for serializing and deserializing using protobuf.

Introduces new producer config field ```format``` with default ```json``` and supporting ```protobuf``` to enable using ProtobufRecordSerializer.  Then consumers can use ProtobufRecordDeserializer to consume record type specific instances


A prime motivator to create this is to be able to implement kafka-importers in ```zeeqs``` and ```zeebe-simple-monitor``` (https://github.com/zeebe-io/zeebe-simple-monitor/pull/183) as well as providing a durable pipeline for exporters 

Replaces https://github.com/zeebe-io/zeebe-kafka-exporter/pull/35