### PR TITLE
Preserves ordering of exported records

### DIFF
--- a/exporter/src/main/java/io/zeebe/exporters/kafka/producer/DefaultKafkaProducerFactory.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/producer/DefaultKafkaProducerFactory.java
@@ -74,6 +74,7 @@ public final class DefaultKafkaProducerFactory implements KafkaProducerFactory {
 
     options.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, RecordIdSerializer.class);
     options.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, RecordSerializer.class);
+    options.put(ProducerConfig.PARTITIONER_CLASS_CONFIG, RecordIdPartitioner.class);
 
     return new KafkaProducer<>(options);
   }

--- a/exporter/src/main/java/io/zeebe/exporters/kafka/producer/RecordIdPartitioner.java
+++ b/exporter/src/main/java/io/zeebe/exporters/kafka/producer/RecordIdPartitioner.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporters.kafka.producer;
+
+import io.zeebe.exporters.kafka.serde.RecordId;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link Partitioner} implementation which expects only {@link RecordId} objects as keys.
+ *
+ * <p>It will partition the records using {@link RecordId#getPartitionId()}, ensuring that all Zeebe
+ * records on the same Zeebe partition will also be on the same Kafka partition, preserving the
+ * ordering. It does so by taking the Zeebe partition ID (which starts at 1), and applying a modulo
+ * against the number of Kafka partitions for the given topic, e.g. {@code zeebePartitionId %
+ * kafkaPartitionsCount}.
+ *
+ * <p>One downside is that if you have more Kafka partitions than Zeebe partitions, some of your
+ * partitions will be unused: partition 0, and any partition whose number is greater than the count
+ * of Zeebe partitions.
+ *
+ * <p>For example, if you have 3 Zeebe partitions, and 2 Kafka partitions:
+ *
+ * <ul>
+ *   <li>RecordId{partitionId=1, position=1} => Kafka partition 1
+ *   <li>RecordId{partitionId=2, position=1} => Kafka partition 0
+ *   <li>RecordId{partitionId=3, position=1} => Kafka partition 1
+ *   <li>RecordId{partitionId=3, position=2} => Kafka partition 1
+ *   <li>RecordId{partitionId=2, position=2} => Kafka partition 0
+ * </ul>
+ *
+ * <p>With more Kafka partitions, for example, 4 Kafka partitions, and 3 Zeebe partitions:
+ *
+ * <ul>
+ *   <li>RecordId{partitionId=1, position=1} => Kafka partition 1
+ *   <li>RecordId{partitionId=2, position=1} => Kafka partition 2
+ *   <li>RecordId{partitionId=3, position=1} => Kafka partition 3
+ *   <li>RecordId{partitionId=3, position=2} => Kafka partition 3
+ *   <li>RecordId{partitionId=2, position=2} => Kafka partition 2
+ * </ul>
+ */
+public class RecordIdPartitioner implements Partitioner {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RecordIdPartitioner.class);
+
+  private final DefaultPartitioner defaultPartitioner = new DefaultPartitioner();
+
+  @Override
+  public int partition(
+      final String topic,
+      final Object key,
+      final byte[] keyBytes,
+      final Object value,
+      final byte[] valueBytes,
+      final Cluster cluster) {
+    if (!(key instanceof RecordId)) {
+      LOGGER.warn(
+          "Expected to partition a RecordId object, but got {}; falling back to default partitioner",
+          key.getClass());
+      return defaultPartitioner.partition(topic, key, keyBytes, value, valueBytes, cluster);
+    }
+
+    final List<PartitionInfo> partitions = cluster.partitionsForTopic(topic);
+    final int numPartitions = partitions.size();
+    final RecordId recordId = (RecordId) key;
+    final int partitionId = recordId.getPartitionId() % numPartitions;
+
+    LOGGER.info("Assigning partition {} to record ID {}", partitionId, recordId);
+
+    return partitionId;
+  }
+
+  @Override
+  public void close() {
+    // do nothing
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs) {
+    // not configurable yet
+  }
+}

--- a/exporter/src/test/java/io/zeebe/exporters/kafka/KafkaExporterIT.java
+++ b/exporter/src/test/java/io/zeebe/exporters/kafka/KafkaExporterIT.java
@@ -18,6 +18,7 @@ package io.zeebe.exporters.kafka;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Maps;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.zeebe.exporters.kafka.config.raw.RawConfig;
 import io.zeebe.exporters.kafka.config.raw.RawProducerConfig;
 import io.zeebe.exporters.kafka.serde.RecordId;
@@ -27,27 +28,48 @@ import io.zeebe.protocol.record.Record;
 import io.zeebe.test.exporter.ExporterIntegrationRule;
 import io.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.KafkaContainer;
 
 public class KafkaExporterIT {
   private static final String TOPIC = "zeebe";
+  private static final int PARTITION_COUNT = 3;
 
   @Rule public RecordingExporterTestWatcher testWatcher = new RecordingExporterTestWatcher();
   @Rule public KafkaContainer kafkaContainer = new KafkaContainer().withEmbeddedZookeeper();
 
   private RawConfig exporterConfiguration;
   private ExporterIntegrationRule exporterIntegrationRule;
+
+  @Before
+  public void setUp() {
+    // provision Kafka topics - this is difficult at the moment to achieve purely via
+    // configuration, so we do it as a pre-step
+    final NewTopic topic = new NewTopic(TOPIC, PARTITION_COUNT, (short) 1);
+    try (final AdminClient admin =
+        AdminClient.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaServer()))) {
+      admin.createTopics(List.of(topic));
+    }
+  }
 
   @After
   public void tearDown() {
@@ -74,30 +96,51 @@ public class KafkaExporterIT {
   }
 
   private void assertRecordsExported() {
-    final Map<RecordId, String> records = consumeAllExportedRecords();
+    final Map<RecordId, ConsumerRecord<RecordId, String>> records = consumeAllExportedRecords();
     exporterIntegrationRule.visitExportedRecords(r -> assertRecordExported(records, r));
+
+    // in order to not depend on implementation detail of how the partitioner works, group the
+    // records as they were produced in partition, and assert that the order is maintained amongst
+    // them, and all records of the same Zeebe partition were produced on the same Kafka partition
+    final Map<Integer, List<ConsumerRecord<RecordId, String>>> perZeebePartition =
+        collectConsumedRecordsByZeebePartition(records);
+
+    // ensure all have the same Kafka partition, and that all are in order by position - as
+    // they are already sorted by offset (so Kafka order), we can ensure they are also
+    // maintaining the same Zeebe order (via position)
+    perZeebePartition.forEach(
+        (partitionId, list) -> {
+          final int kafkaPartition = list.get(0).partition();
+          assertThat(list)
+              .allSatisfy(r -> assertThat(r.partition()).isEqualTo(kafkaPartition))
+              .isSortedAccordingTo(
+                  Comparator.comparing(r -> r.key().getPosition(), Long::compareTo));
+        });
   }
 
   private void assertRecordExported(
-      final Map<RecordId, String> producedRecords, final Record<?> record) {
-    final String producedRecord =
-        producedRecords.get(new RecordId(record.getPartitionId(), record.getPosition()));
+      final Map<RecordId, ConsumerRecord<RecordId, String>> producedRecords,
+      final Record<?> record) {
+    final RecordId recordId = new RecordId(record.getPartitionId(), record.getPosition());
+    final ConsumerRecord<RecordId, String> producedRecord = producedRecords.get(recordId);
 
     assertThat(producedRecord).isNotNull();
-    JsonAssertions.assertThat(producedRecord).isJsonEqualTo(record.toJson());
+    JsonAssertions.assertThat(producedRecord.value()).isJsonEqualTo(record.toJson());
   }
 
-  private Map<RecordId, String> consumeAllExportedRecords() {
-    final Map<RecordId, String> records = new HashMap<>();
+  @NonNull
+  private Map<RecordId, ConsumerRecord<RecordId, String>> consumeAllExportedRecords() {
+    final Map<RecordId, ConsumerRecord<RecordId, String>> records = new LinkedHashMap<>();
     final Duration timeout = Duration.ofSeconds(5);
 
     try (Consumer<RecordId, String> consumer = newConsumer()) {
-      consumer.poll(timeout).forEach(r -> records.put(r.key(), r.value()));
+      consumer.poll(timeout).forEach(r -> records.put(r.key(), r));
     }
 
     return records;
   }
 
+  @NonNull
   private Consumer<RecordId, String> newConsumer() {
     final Properties properties = consumerConfig();
     final Deserializer<RecordId> keyDeserializer = new RecordIdDeserializer();
@@ -112,6 +155,7 @@ public class KafkaExporterIT {
     return consumer;
   }
 
+  @NonNull
   private RawConfig newConfiguration() {
     final RawConfig configuration = new RawConfig();
     configuration.maxInFlightRecords = 30;
@@ -125,9 +169,11 @@ public class KafkaExporterIT {
     exporterConfiguration = newConfiguration();
     exporterIntegrationRule = new ExporterIntegrationRule();
     exporterIntegrationRule.configure("kafka", KafkaExporter.class, exporterConfiguration);
+    exporterIntegrationRule.getBrokerConfig().getCluster().setPartitionsCount(PARTITION_COUNT);
     exporterIntegrationRule.start();
   }
 
+  @NonNull
   private Properties consumerConfig() {
     final Properties properties = new Properties();
     properties.put("auto.commit.interval.ms", "100");
@@ -143,10 +189,31 @@ public class KafkaExporterIT {
     return properties;
   }
 
+  @NonNull
   private String getKafkaServer() {
     return String.format(
         "%s:%d",
         kafkaContainer.getContainerIpAddress(),
         kafkaContainer.getMappedPort(KafkaContainer.KAFKA_PORT));
+  }
+
+  @NonNull
+  private Map<Integer, List<ConsumerRecord<RecordId, String>>>
+      collectConsumedRecordsByZeebePartition(
+          final Map<RecordId, ConsumerRecord<RecordId, String>> records) {
+    final Map<Integer, List<ConsumerRecord<RecordId, String>>> perZeebePartition = new HashMap<>();
+    records
+        .values()
+        .forEach(
+            r -> {
+              final List<ConsumerRecord<RecordId, String>> perZeebePartitionList =
+                  perZeebePartition.computeIfAbsent(
+                      r.key().getPartitionId(), partitionId -> new ArrayList<>());
+
+              perZeebePartitionList.add(r);
+              perZeebePartitionList.sort(
+                  Comparator.comparing(ConsumerRecord::offset, Long::compareTo));
+            });
+    return perZeebePartition;
   }
 }

--- a/exporter/src/test/java/io/zeebe/exporters/kafka/config/parser/RawProducerConfigParserTest.java
+++ b/exporter/src/test/java/io/zeebe/exporters/kafka/config/parser/RawProducerConfigParserTest.java
@@ -38,12 +38,7 @@ public class RawProducerConfigParserTest {
 
     // then
     assertThat(parsed)
-        .extracting(
-            "servers",
-            "clientId",
-            "closeTimeout",
-            "requestTimeout",
-            "config")
+        .extracting("servers", "clientId", "closeTimeout", "requestTimeout", "config")
         .containsExactly(
             RawProducerConfigParser.DEFAULT_SERVERS,
             RawProducerConfigParser.DEFAULT_CLIENT_ID,
@@ -67,12 +62,7 @@ public class RawProducerConfigParserTest {
 
     // then
     assertThat(parsed)
-        .extracting(
-            "servers",
-            "clientId",
-            "closeTimeout",
-            "requestTimeout",
-            "config")
+        .extracting("servers", "clientId", "closeTimeout", "requestTimeout", "config")
         .containsExactly(
             Collections.singletonList("localhost:3000"),
             "client",


### PR DESCRIPTION
**Description**

This PR implements a new `Partitioner` which assigns a consistent Kafka partition for all Zeebe records which share the same Zeebe partition, thereby preserving the ordering in which they were written in Zeebe (for a given Kafka topic).

The current approach is suboptimal - it simply maps the `zeebePartitionId` using a simple modulo over the count of Kafka partitions for a given topic. This means if there are more Kafka partitions than Zeebe partitions, some of these partitions will be unused - however it solves an important issue, so it's a good interim solution until a better one is found.

**Related issues**

closes #31 